### PR TITLE
fix key-prefixing and test setup for cluster mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ workflows:
           docker-image: cimg/go:1.15
           with-coverage: true
           run-lint: true
+      - go-test-cluster:
+          name: Go 1.15 with cluster
+          docker-image: cimg/go:1.15
       - go-test:
           name: Go 1.14
           docker-image: cimg/go:1.14
@@ -70,6 +73,72 @@ jobs:
                 name: Store coverage results
                 command: cp build/coverage* /tmp/circle-artifacts
                 when: always
+    
+      - run:
+          name: Process test results
+          command: go-junit-report < $CIRCLE_ARTIFACTS/report.txt > $CIRCLE_TEST_REPORTS/junit.xml
+          when: always
+      
+      - store_test_results:
+          path: /tmp/circle-reports
+
+      - store_artifacts:
+          path: /tmp/circle-artifacts
+
+  go-test-cluster:
+    parameters:
+      docker-image:
+        type: string
+  
+    docker:
+      - image: <<parameters.docker-image>>
+        environment:
+          LD_TEST_REDIS_ADDRESSES: redis-node1:6379 redis-node2:6379 redis-node3:6379
+          CIRCLE_TEST_REPORTS: /tmp/circle-reports
+          CIRCLE_ARTIFACTS: /tmp/circle-artifacts
+      - name: redis-node1
+        image: bitnami/redis-cluster:latest
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+      - name: redis-node2
+        image: bitnami/redis-cluster:latest
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+      - name: redis-node3
+        image: bitnami/redis-cluster:latest
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+      - name: redis-cluster-init
+        image: bitnami/redis-cluster:latest
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_CLUSTER_CREATOR: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+
+    steps:
+      - checkout
+
+      - run:
+          name: install go-junit-report
+          command: go get -u github.com/jstemmer/go-junit-report
+
+      - run:
+          name: Build
+          command: make
+
+      - run:
+          name: Run tests
+          command: |
+            mkdir -p $CIRCLE_TEST_REPORTS
+            mkdir -p $CIRCLE_ARTIFACTS
+            make test | tee $CIRCLE_ARTIFACTS/report.txt
     
       - run:
           name: Process test results


### PR DESCRIPTION
After adding a CI job that runs the database integration tests against an actual Redis cluster, I found some problems in 1. the logic for computing the keys and 2. the test setup code that clears out data from previous tests. See PR comments.