### PR TITLE
rework configuration, add explicit Redis Sentinel support, change hashtag logic

### DIFF
--- a/redis_builder_test.go
+++ b/redis_builder_test.go
@@ -3,27 +3,37 @@ package ldredis
 import (
 	"testing"
 
+	"gopkg.in/launchdarkly/go-server-sdk.v5/testhelpers"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDataSourceBuilder(t *testing.T) {
+	makeStore := func(b *DataStoreBuilder) *redisDataStoreImpl {
+		b.CheckOnStartup(false)
+		store, err := b.CreatePersistentDataStore(testhelpers.NewSimpleClientContext(""))
+		require.NoError(t, err)
+		return store.(*redisDataStoreImpl)
+	}
+
 	t.Run("defaults", func(t *testing.T) {
-		b := DataStore()
-		assert.Equal(t, DefaultPrefix, b.prefix)
-		assert.Equal(t, "", b.url)
+		store := makeStore(DataStore())
+		assert.Equal(t, DefaultPrefix, store.prefix)
+		assert.Equal(t, []string{defaultAddress}, store.redisOpts.Addrs)
 	})
 
 	t.Run("HostAndPort", func(t *testing.T) {
 		b := DataStore().HostAndPort("mine", 4000)
-		assert.Equal(t, []string{"mine:4000"}, b.redisOpts.Addrs)
+		assert.Equal(t, []string{"mine:4000"}, makeStore(b).redisOpts.Addrs)
 	})
 
 	t.Run("Prefix", func(t *testing.T) {
-		b := DataStore().Prefix("p")
-		assert.Equal(t, "p", b.prefix)
+		assert.Equal(t, "p", makeStore(DataStore().Prefix("p")).prefix)
 
-		b.Prefix("")
-		assert.Equal(t, DefaultPrefix, b.prefix)
+		assert.Equal(t, DefaultPrefix, makeStore(DataStore().Prefix("")).prefix)
+
+		// assert.Equal(t, DefaultClusterPrefix + "p", makeStore(DataStore().Prefix("p").))
 	})
 
 	t.Run("URL", func(t *testing.T) {

--- a/redis_test.go
+++ b/redis_test.go
@@ -72,7 +72,7 @@ func clearTestData(prefix string) error {
 	}
 
 	if isClusterMode() {
-		prefix = hashTag + prefix
+		prefix = DefaultClusterPrefix + prefix
 		clusterClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: getTestAddresses()})
 		defer clusterClient.Close()
 		return clusterClient.ForEachMaster(defaultContext(), func(ctx context.Context, client *redis.Client) error {


### PR DESCRIPTION
1. Make it a little clearer how to set things up if you're using Redis Sentinel, by surfacing `Master` as a top-level method (instead of just an option within `redis.UniversalOptions`) and talking about Sentinel in the doc comment for `Addresses`. There aren't any implementation changes here for supporting Sentinel - the `go-redis` client should already be able to handle that. We don't have CI tests for this yet, though.
2. Instead of always adding `{ld}.` to the prefix, add this only if the configured prefix doesn't already have curly braces in it - so the application can include its own custom hashtag in a custom prefix if desired.