### PR TITLE
ci: switch to Github Actions

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -1,0 +1,38 @@
+name: Coverage
+description: "Runs code-coverage checker."
+inputs:
+  enforce:
+    description: 'Whether to enforce coverage thresholds.'
+    required: false
+    default: 'false'
+
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/get-go-version
+      id: go-version
+
+    - name: Test with coverage
+      shell: bash
+      id: test-coverage
+      run: |
+        set +e
+        make test-coverage
+        status=$?
+        echo "coverage_status=$status" >> $GITHUB_OUTPUT
+
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: Coverage-result-${{ steps.go-version.outputs.version }}
+        path: build/coverage*
+
+    - name: Enforce coverage
+      shell: bash
+      if: steps.test-coverage.outputs.coverage_status != '0'
+      run: |
+        echo "Code isn't fully covered!"
+        if [ "${{ inputs.enforce }}" == "true" ]; 
+          exit 1
+        fi

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -33,6 +33,6 @@ runs:
       if: steps.test-coverage.outputs.coverage_status != '0'
       run: |
         echo "Code isn't fully covered!"
-        if [ "${{ inputs.enforce }}" == "true" ]; 
+        if [[ "${{ inputs.enforce }}" == "true" ]]; then
           exit 1
         fi

--- a/.github/actions/get-go-version/action.yml
+++ b/.github/actions/get-go-version/action.yml
@@ -1,0 +1,15 @@
+name: Get Go Version
+description: "Gets the currently installed Go version."
+outputs:
+  version:
+    description: 'The currently installed Go version.'
+    value: ${{ steps.go-version.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get Go version
+      id: go-version
+      shell: bash
+      run: |
+        echo "value=$(go version | awk '{print $3}')" >> $GITHUB_OUTPUT

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -1,0 +1,35 @@
+name: Unit Tests
+description: "Runs unit tests + linters and optionally gathers coverage."
+inputs:
+  lint:
+    description: 'Whether to run linters.'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/get-go-version
+      id: go-version
+    - name: Lint
+      if: inputs.lint == 'true'
+      shell: bash
+      run: make lint
+
+    - name: Test
+      shell: bash
+      id: test
+      run: make test | tee raw_report.txt
+
+    - name: Process test results
+      if: steps.test.outcome == 'success'
+      id: process-test
+      shell: bash
+      run: go run github.com/jstemmer/go-junit-report@v0.9.1 < raw_report.txt > junit_report.xml
+
+    - name: Upload test results
+      if: steps.process-test.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test-result-${{ steps.go-version.outputs.version }}
+        path: junit_report.xml

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Whether to run linters.'
     required: false
     default: 'false'
+  upload-results:
+    description: 'Whether to upload test results.'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -22,7 +26,7 @@ runs:
       run: make test | tee raw_report.txt
 
     - name: Process test results
-      if: steps.test.outcome == 'success'
+      if: steps.test.outcome == 'success' && inputs.upload-results == 'true'
       id: process-test
       shell: bash
       run: go run github.com/jstemmer/go-junit-report@v0.9.1 < raw_report.txt > junit_report.xml

--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,0 +1,3 @@
+latest=1.23
+penultimate=1.22
+min=1.19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           ALLOW_EMPTY_PASSWORD: yes
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
-        ports:
-          - 6376:6379
+
 
       redis-node2:
         image: bitnami/redis-cluster:latest
@@ -52,8 +51,7 @@ jobs:
           ALLOW_EMPTY_PASSWORD: yes
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
-        ports:
-          - 6377:6379
+
 
       redis-node3:
         image: bitnami/redis-cluster:latest
@@ -61,8 +59,7 @@ jobs:
           ALLOW_EMPTY_PASSWORD: yes
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
-        ports:
-          - 6378:6379
+
 
       redis-cluster-init:
         image: bitnami/redis-cluster:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: ${{ format('Linux, Go {0} with Redis Cluster', matrix.go-version) }}
     runs-on: ubuntu-latest
     env:
-      LD_TEST_REDIS_ADDRESSES: redis-node1:6379 redis-node2:6379 redis-node3:6379
+      LD_TEST_REDIS_ADDRESSES: redis-node1:6376 redis-node2:6377 redis-node3:6378
     needs: go-versions
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
         ports:
-          - 6379:6379
+          - 6376:6379
 
       redis-node2:
         image: bitnami/redis-cluster:latest
@@ -53,7 +53,7 @@ jobs:
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
         ports:
-          - 6379:6379
+          - 6377:6379
 
       redis-node3:
         image: bitnami/redis-cluster:latest
@@ -62,7 +62,7 @@ jobs:
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
         ports:
-          - 6379:6379
+          - 6378:6379
 
       redis-cluster-init:
         image: bitnami/redis-cluster:latest
@@ -71,8 +71,7 @@ jobs:
           REDIS_CLUSTER_CREATOR: yes
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
-        ports:
-          - 6379:6379
+
     steps:
      - uses: actions/checkout@v4
      - name: Setup Go ${{ inputs.go-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: Build and Test
+on:
+  push:
+    branches: [ 'main', 'feat/**' ]
+    paths-ignore:
+      - '**.md' # Don't run CI on markdown changes.
+  pull_request:
+    branches: [ 'main', 'feat/**'  ]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  go-versions:
+    uses: ./.github/workflows/go-versions.yml
+
+  # Runs the common tasks (unit tests, lint, contract tests) for each Go version.
+  test-linux:
+    name: ${{ format('Linux, Go {0}', matrix.go-version) }}
+    needs: go-versions
+    strategy:
+      # Let jobs fail independently, in case it's a single version that's broken.
+      fail-fast: false
+      matrix:
+        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+    uses: ./.github/workflows/common_ci.yml
+    with:
+      go-version: ${{ matrix.go-version }}
+
+  test-windows:
+    name: ${{ format('Windows, Go {0}', matrix.go-version) }}
+    runs-on: windows-2022
+    needs: go-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Test
+        run: go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
 
       - name: Run Redis
         run: docker run -d -p 6379:6379 --name redis-server -p 6379:6379 redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Setup Redis
-        uses: supercharge/redis-github-action@ea9b21c6ecece47bd99595c532e481390ea0f044
+      - name: Setup Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Redis
+        run: docker run -d -p 6379:6379 --name redis-server -p 6379:6379 redis
+
+      - name: Check Redis connection
+        run: docker run --rm --link redis-server:redis redis redis-cli -h redis ping
+
       - name: Test
         run: go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
          apt-get update
          apt-get install -y make curl gcc
      - uses: ./.github/actions/unit-tests
+       with:
+         upload-results: 'false'
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,67 @@ jobs:
     with:
       go-version: ${{ matrix.go-version }}
 
+  test-linux-redis-cluster:
+    name: ${{ format('Linux, Go {0} with Redis Cluster', matrix.go-version) }}
+    runs-on: ubuntu-latest
+    env:
+      LD_TEST_REDIS_ADDRESSES: redis-node1:6379 redis-node2:6379 redis-node3:6379
+    needs: go-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+    services:
+      redis-node1:
+        image: bitnami/redis-cluster:latest
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+        ports:
+          - 6379:6379
+
+      redis-node2:
+        image: bitnami/redis-cluster:latest
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+        ports:
+          - 6379:6379
+
+      redis-node3:
+        image: bitnami/redis-cluster:latest
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+        ports:
+          - 6379:6379
+
+      redis-cluster-init:
+        image: bitnami/redis-cluster:latest
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_CLUSTER_CREATOR: yes
+          REDIS_NODES: redis-node1 redis-node2 redis-node3
+          REDIS_CLUSTER_REPLICAS: 0
+        ports:
+          - 6379:6379
+    steps:
+     - uses: actions/checkout@v4
+     - name: Setup Go ${{ inputs.go-version }}
+       uses: actions/setup-go@v5
+       with:
+         go-version: ${{ inputs.go-version }}
+     - uses: ./.github/actions/unit-tests
+       with:
+         lint: 'true'
+     - uses: ./.github/actions/coverage
+       with:
+         enforce: 'false'
+
+
   test-windows:
     name: ${{ format('Windows, Go {0}', matrix.go-version) }}
     runs-on: windows-2022
@@ -42,9 +103,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Install Redis
         shell: powershell
-        # Note, the redis-64 package is deprecated and no longer maintained so it does
-        # not include improvements made in Redis after Redis 3.x, and it would not be
-        # good to use it in production. But for our testing purposes here it's adequate.
         run: |
           choco install redis
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Setup Docker
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
-
-      - name: Run Redis
-        run: docker run -d -p 6379:6379 --name redis-server -p 6379:6379 redis
-
-      - name: Check Redis connection
-        run: docker run --rm --link redis-server:redis redis redis-cli -h redis ping
-
+      - name: Install Redis
+        shell: powershell
+        # Note, the redis-64 package is deprecated and no longer maintained so it does
+        # not include improvements made in Redis after Redis 3.x, and it would not be
+        # good to use it in production. But for our testing purposes here it's adequate.
+        run: |
+          choco install redis-64
       - name: Test
         run: go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: ${{ format('Linux, Go {0} with Redis Cluster', matrix.go-version) }}
     runs-on: ubuntu-latest
     env:
-      LD_TEST_REDIS_ADDRESSES: redis-node1:6376 redis-node2:6377 redis-node3:6378
+      LD_TEST_REDIS_ADDRESSES: redis-node1:6379 redis-node2:6379 redis-node3:6379
     needs: go-versions
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
        run: |
          apt-get update
          apt-get install -y make curl gcc
+     - name: Sleep
+       run: sleep 35
      - uses: ./.github/actions/unit-tests
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         env:
           ALLOW_EMPTY_PASSWORD: yes
           REDIS_CLUSTER_CREATOR: yes
+          REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP: 30
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,21 +71,20 @@ jobs:
           REDIS_CLUSTER_REPLICAS: 0
 
     container:
-      image: ghcr.io/actions/actions-runner:latest
+      image: ubuntu:22.04
     steps:
      - uses: actions/checkout@v4
      - name: Setup Go ${{ matrix.go-version }}
        uses: actions/setup-go@v5
        with:
          go-version: ${{ matrix.go-version }}
-     - name: Install make
-       run: sudo apt-get -y install make curl
+     - name: Deps
+       run: |
+         apt-get update
+         apt-get install -y make curl gcc
      - uses: ./.github/actions/unit-tests
-       with:
-         lint: 'true'
-     - uses: ./.github/actions/coverage
-       with:
-         enforce: 'false'
+
+
 
 
   test-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         env:
           ALLOW_EMPTY_PASSWORD: yes
           REDIS_CLUSTER_CREATOR: yes
-          REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP: 30
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
 
@@ -82,8 +81,6 @@ jobs:
        run: |
          apt-get update
          apt-get install -y make curl gcc
-     - name: Sleep
-       run: sleep 35
      - uses: ./.github/actions/unit-tests
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
   test-windows:
     name: ${{ format('Windows, Go {0}', matrix.go-version) }}
     runs-on: windows-2022
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     needs: go-versions
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,16 @@ jobs:
           REDIS_NODES: redis-node1 redis-node2 redis-node3
           REDIS_CLUSTER_REPLICAS: 0
 
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     steps:
      - uses: actions/checkout@v4
-     - name: Setup Go ${{ inputs.go-version }}
+     - name: Setup Go ${{ matrix.go-version }}
        uses: actions/setup-go@v5
        with:
-         go-version: ${{ inputs.go-version }}
+         go-version: ${{ matrix.go-version }}
+     - name: Install make
+       run: sudo apt-get -y install make curl
      - uses: ./.github/actions/unit-tests
        with:
          lint: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,6 @@ jobs:
         # not include improvements made in Redis after Redis 3.x, and it would not be
         # good to use it in production. But for our testing purposes here it's adequate.
         run: |
-          choco install redis-64
+          choco install redis
       - name: Test
         run: go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,6 @@ jobs:
   test-windows:
     name: ${{ format('Windows, Go {0}', matrix.go-version) }}
     runs-on: windows-2022
-    services:
-      redis:
-        image: redis
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
     needs: go-versions
     strategy:
       fail-fast: false
@@ -50,5 +40,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Setup Redis
+        uses: supercharge/redis-github-action@ea9b21c6ecece47bd99595c532e481390ea0f044
       - name: Test
         run: go test -race ./...

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -1,0 +1,36 @@
+name: Common CI
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: "Go version to use for the jobs."
+        required: true
+        type: string
+
+jobs:
+  unit-test-and-coverage:
+    runs-on: ubuntu-latest
+    name: 'Unit Tests and Coverage'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ inputs.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+      - uses: ./.github/actions/unit-tests
+        with:
+          lint: 'true'
+      - uses: ./.github/actions/coverage
+        with:
+          enforce: 'false'
+
+  benchmarks:
+    name: 'Benchmarks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ inputs.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+      - uses: ./.github/actions/benchmarks

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -11,6 +11,14 @@ jobs:
   unit-test-and-coverage:
     runs-on: ubuntu-latest
     name: 'Unit Tests and Coverage'
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -31,14 +31,3 @@ jobs:
       - uses: ./.github/actions/coverage
         with:
           enforce: 'false'
-
-  benchmarks:
-    name: 'Benchmarks'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ inputs.go-version }}
-      - uses: ./.github/actions/benchmarks

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -19,6 +19,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ inputs.go-version }}

--- a/.github/workflows/go-versions.yml
+++ b/.github/workflows/go-versions.yml
@@ -1,0 +1,52 @@
+# The following chunk of yml boils down to pulling two Go version numbers out of a file and
+# making them available to the other workflows in a convenient fashion.
+#
+# It's a reusable workflow instead of an action so that its output can be used in a matrix strategy
+# of another job.
+#
+# The idea is to define the most recent, and penultimate, Go versions that should be used to test Relay.
+# Ideally we'd define these in a single place - otherwise we'd need to update many different places in
+# each workflow. This single place is .github/variables/go-versions.env.
+#
+# This reusable workflow grabs them out of the file, then sets them as outputs. As a convenience, it
+# also wraps each version in an array, so it can be directly used in a matrix strategy. Single-item matrices
+# are nice because you can tell instantly in the Github UI which version is being tested without needing
+# to inspect logs.
+#
+# To use a matrix output, e.g. latest version, do:
+#  strategy:
+#    matrix: ${{ fromJSON(this-job.outputs.latest-matrix) }}
+#
+name: Go Versions
+on:
+  workflow_call:
+    outputs:
+      latest:
+        description: 'The most recent Go version to test'
+        value: ${{ jobs.go-versions.outputs.latest }}
+      penultimate:
+        description: 'The second most recent Go version to test'
+        value: ${{ jobs.go-versions.outputs.penultimate }}
+      min:
+        description: 'The minimum Go version to test'
+        value: ${{ jobs.go-versions.outputs.min }}
+      matrix:
+        description: 'All Go versions to test as a matrix'
+        value: ${{ jobs.go-versions.outputs.all }}
+
+jobs:
+  go-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.set-env.outputs.latest }}
+      penultimate: ${{ steps.set-env.outputs.penultimate }}
+      all: ${{ steps.set-matrix.outputs.all }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Go Versions
+        id: set-env
+        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+      - name: Set Go Version Matrices
+        id: set-matrix
+        run: |
+          echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\",\"${{ steps.set-env.outputs.min }}\"]" >> $GITHUB_OUTPUT

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,10 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    # Happen once per day at 1:30 AM
+    - cron: '30 1 * * *'
+
+jobs:
+  sdk-close-stale:
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@main

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GOLANGCI_LINT_VERSION=v1.48.0
+GOLANGCI_LINT_VERSION=v1.60.1
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 	go clean
 
 test:
-	go test -race -v ./...
+	CGO_ENABLED=1 go test -race -v ./...
 
 test-coverage: $(COVERAGE_PROFILE_RAW)
 	if [ -x "$(GOPATH)/bin/go-coverage-enforcer)" ]; then go get github.com/launchdarkly-labs/go-coverage-enforcer; fi

--- a/redis_test.go
+++ b/redis_test.go
@@ -2,9 +2,7 @@ package ldredis
 
 import (
 	"context"
-	"errors"
 	"github.com/redis/go-redis/v9"
-	"net"
 	"os"
 	"strings"
 	"testing"
@@ -47,7 +45,7 @@ func makeFailedStore() subsystems.ComponentConfigurer[subsystems.PersistentDataS
 }
 
 func verifyFailedStoreError(t assert.TestingT, err error) {
-	assert.True(t, errors.Is(err, &net.DNSError{}))
+	assert.Contains(t, err.Error(), "lookup")
 }
 
 func clearTestData(prefix string) error {

--- a/redis_test.go
+++ b/redis_test.go
@@ -2,7 +2,9 @@ package ldredis
 
 import (
 	"context"
+	"errors"
 	"github.com/redis/go-redis/v9"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -45,7 +47,7 @@ func makeFailedStore() subsystems.ComponentConfigurer[subsystems.PersistentDataS
 }
 
 func verifyFailedStoreError(t assert.TestingT, err error) {
-	assert.Contains(t, err.Error(), "no such host")
+	assert.True(t, errors.Is(err, &net.DNSError{}))
 }
 
 func clearTestData(prefix string) error {


### PR DESCRIPTION
This converts the repo to Github Actions for CI.

Of note, the Github windows runner does not support containers, so it's using a Chocolatey package for Redis. 

Additionally, to get the redis cluster networking to work properly when using the `services` config, I had to run the CI job in a container rather than on the `ubuntu-latest` runner itself. So, it's running in `ubuntu:22.04` with essential packages installed. 