### PR TITLE
fix: Return an error when Upsert exhausts its retry attempts

### DIFF
--- a/redis_impl.go
+++ b/redis_impl.go
@@ -3,6 +3,8 @@ package ldredis
 import (
 	"context"
 	"errors"
+	"fmt"
+
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 	"github.com/redis/go-redis/v9"
@@ -10,7 +12,12 @@ import (
 
 const (
 	defaultAddress = "localhost:6379"
-	maxRetries     = 10
+
+	// The maximum number of attempts Upsert will make before giving up. WATCH covers the entire
+	// hash for a data kind rather than the individual item key, so every concurrent update of that
+	// kind contends on the same key; without a limit a caller could be starved indefinitely during
+	// a burst of updates.
+	maxRetries = 10
 )
 
 // Internal implementation of the PersistentDataStore interface for Redis.
@@ -88,6 +95,9 @@ func (store *redisDataStoreImpl) GetAll(
 	return results, nil
 }
 
+// Upsert retries the update as long as another client keeps modifying the watched key, up to
+// maxRetries attempts. If the attempts run out, the item was not written and an error is returned
+// so that the SDK can treat the store as unavailable and refresh it once it recovers.
 func (store *redisDataStoreImpl) Upsert(
 	kind ldstoretypes.DataKind,
 	key string,
@@ -97,7 +107,6 @@ func (store *redisDataStoreImpl) Upsert(
 
 	finished := false
 	updated := false
-	var retryErr error
 
 	for availableRetries := maxRetries; availableRetries > 0; availableRetries-- {
 		err := store.client.Watch(defaultContext(), func(tx *redis.Tx) error {
@@ -162,7 +171,8 @@ func (store *redisDataStoreImpl) Upsert(
 			return updated, nil
 		}
 	}
-	return false, retryErr
+	return false, fmt.Errorf("failed to update key %q in %q after %d attempts",
+		key, kind.GetName(), maxRetries)
 }
 
 func (store *redisDataStoreImpl) IsInitialized() bool {

--- a/redis_test.go
+++ b/redis_test.go
@@ -2,14 +2,18 @@ package ldredis
 
 import (
 	"context"
-	"github.com/redis/go-redis/v9"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/redis/go-redis/v9"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/storetest"
 )
 
@@ -87,4 +91,36 @@ func clearTestData(prefix string) error {
 
 func setConcurrentModificationHook(store subsystems.PersistentDataStore, hook func()) {
 	store.(*redisDataStoreImpl).testTxHook = hook
+}
+
+func TestUpsertGivesUpAfterMaxRetries(t *testing.T) {
+	prefix := "test-upsert-gives-up"
+	require.NoError(t, clearTestData(prefix))
+
+	store, err := makeTestStore(prefix).Build(subsystems.BasicClientContext{})
+	require.NoError(t, err)
+	defer store.Close() //nolint:errcheck // test cleanup
+
+	impl := store.(*redisDataStoreImpl)
+	kind := ldstoreimpl.Features()
+	hashKey := impl.keyForKind(kind)
+
+	// Touch the watched hash from a separate client on every attempt, so each transaction sees a
+	// concurrent modification and the key looks perpetually contended.
+	otherClient := redis.NewUniversalClient(makeClientOptions())
+	defer otherClient.Close() //nolint:errcheck // test cleanup
+	attempts := 0
+	impl.testTxHook = func() {
+		attempts++
+		require.NoError(t, otherClient.HSet(defaultContext(), hashKey, "flag-key", `{"key":"flag-key","version":1}`).Err())
+	}
+
+	updated, err := store.Upsert(kind, "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        2,
+		SerializedItem: []byte(`{"key":"flag-key","version":2}`),
+	})
+
+	require.False(t, updated, "an abandoned update must not be reported as an update")
+	require.EqualError(t, err, `failed to update key "flag-key" in "features" after 10 attempts`)
+	require.Equal(t, maxRetries, attempts, "Upsert should make exactly maxRetries attempts")
 }


### PR DESCRIPTION
The optimistic-concurrency loop in Upsert caps its attempts at
maxRetries (10), but the exhaustion path returned (false, nil): the
retryErr variable it returned was declared and never assigned. That
result is indistinguishable from the legitimate "a newer version is
already present, nothing to do" case, so the SDK's persistent store
wrapper treated the abandoned write as a successful no-op and the
update was silently lost, with nothing logged at any level.

WATCH covers the entire hash for a data kind rather than the
individual item key, so every concurrent update of that kind contends
on the same key and a flag-change burst can realistically exhaust the
attempts.

Return a descriptive error instead, matching the redigo implementation
of this store, so the SDK marks the store unavailable and refreshes it
once it recovers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistent-store write failure signaling; previously silent write loss under contention, now surfaces errors that affect SDK store availability and refresh behavior.
> 
> **Overview**
> Fixes a bug where **`Upsert`** could exhaust its optimistic-concurrency retries and still return **`(false, nil)`**, which looked like a successful “nothing to write” outcome and let the SDK treat a failed write as a no-op.
> 
> After **`maxRetries`** (10) failed **`WATCH`** cycles, the store now returns a descriptive **`fmt.Errorf`** (aligned with the redigo implementation) so callers can mark the store unavailable and refresh. Comments document why contention is per data-kind hash, not per item key.
> 
> Adds **`TestUpsertGivesUpAfterMaxRetries`**, which forces contention on every attempt via **`testTxHook`** and asserts no update, the exact error message, and exactly 10 attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd063f9392e6d285044cbacf112cae11fd481f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->